### PR TITLE
Add /pr cursor command for PR creation workflow

### DIFF
--- a/Mackup/.cursor/commands/pr.md
+++ b/Mackup/.cursor/commands/pr.md
@@ -16,13 +16,27 @@ git status --porcelain
 ```
 
 If there is any output, run the commit process:
-1. Run `git status` to understand the current state.
-2. Use `git diff` (and open files only as needed) to understand the change(s).
-  - Do **not** run `git log` unless explicitly requested.
-3. Determine a concise, plain commit message (no prefixes like `docs(...)`) focused on **why** the change was made.
-4. Run `git save --message "<message>" --yes` which will add all changes, commit, and push.
+  1. Run `git status` to understand the current state.
+  2. Use `git diff` (and open files only as needed) to understand the change(s).
+    - Do **not** run `git log` unless explicitly requested.
+  3. Determine a concise, plain commit message (no prefixes like `docs(...)`) focused on **why** the change was made.
+  4. Run `git save --message "<message>" --yes` which will add all changes, commit, and push.
 
-5. Craft a thorough title & description. Use `git diff` when necessary. Create a PR using `gh`:
+5. Craft a thorough title & description. Use `git diff` when necessary. The description should include:
+  - Summary: 1-3 bullets describing the change and why it matters.
+  - Test plan (if applicable): checklist of what you ran or "not run (reason)". Only include test validations that were done by the agent.
+
+  Example description:
+  ```
+  ## Summary
+  - <what changed and why>
+  - <impact or behavior change>
+
+  ## Test plan
+  - <command ran and what it validates>
+  ```
+
+Create a PR using `gh`:
 
 ```shell
 gh pr create --title "<pr title>" --body "<description>" --base "<base branch>"

--- a/Mackup/.cursor/commands/pr.md
+++ b/Mackup/.cursor/commands/pr.md
@@ -15,10 +15,17 @@ fi
 git status --porcelain
 ```
 
-If there is any output, follow the commit process in `commit.md`
+If there is any output, run the commit process:
+1. Run `git status` to understand the current state.
+2. Use `git diff` (and open files only as needed) to understand the change(s).
+  - Do **not** run `git log` unless explicitly requested.
+3. Determine a concise, plain commit message (no prefixes like `docs(...)`) focused on **why** the change was made.
+4. Run `git save --message "<message>" --yes` which will add all changes, commit, and push.
 
 5. Craft a thorough title & description. Use `git diff` when necessary. Create a PR using `gh`:
 
 ```shell
 gh pr create --title "<pr title>" --body "<description>" --base "<base branch>"
 ```
+
+6. Open the PR with `open <url>`.

--- a/Mackup/.cursor/commands/pr.md
+++ b/Mackup/.cursor/commands/pr.md
@@ -1,0 +1,24 @@
+1. Run unit tests via `toolbelt unit` and ensure they pass.
+2. Run `git-town branch` to know the base branch.
+3. Ensure you are on a branch (not `main`/`master`). If you are on `main`/`master`, create and switch to a new branch with a sensible name prefixed with `devon/` (snake-case is preferred):
+
+```shell
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  git switch -c "devon/<short-description>"
+fi
+```
+
+4. Ensure all changes are committed (working tree must be clean):
+
+```shell
+git status --porcelain
+```
+
+If there is any output, follow the commit process in `commit.md`
+
+5. Craft a thorough title & description. Use `git diff` when necessary. Create a PR using `gh`:
+
+```shell
+gh pr create --title "<pr title>" --body "<description>" --base "<base branch>"
+```

--- a/Mackup/.cursor/commands/validate.md
+++ b/Mackup/.cursor/commands/validate.md
@@ -15,7 +15,7 @@ You are a scrupulous senior software engineer performing a production-quality co
    - Readability: Clear logic flow, appropriate abstraction levels, self-documenting code
    - Naming: Consistent, descriptive variable/function/class names without typos
    - Simplicity: Minimal complexity, avoiding over-engineering or premature optimization
-   - Dead code: Unused variables, functions, imports, or unreachable code paths
+   - Dead code: Unused variables, functions, unreachable code paths or source code that is only referenced in tests
    - Style: Adherence to project coding conventions and formatting standards
    - Documentation: Appropriate comments for complex logic, updated docstrings
 

--- a/Mackup/.cursor/commands/validate.md
+++ b/Mackup/.cursor/commands/validate.md
@@ -15,6 +15,7 @@ You are a scrupulous senior software engineer performing a production-quality co
    - Readability: Clear logic flow, appropriate abstraction levels, self-documenting code
    - Naming: Consistent, descriptive variable/function/class names without typos
    - Simplicity: Minimal complexity, avoiding over-engineering or premature optimization
+   - Dead code: Unused variables, functions, imports, or unreachable code paths
    - Style: Adherence to project coding conventions and formatting standards
    - Documentation: Appropriate comments for complex logic, updated docstrings
 

--- a/cursor/rules/.gitignore.mdc
+++ b/cursor/rules/.gitignore.mdc
@@ -1,0 +1,5 @@
+---
+globs: **/.gitignore
+alwaysApply: false
+---
+Don't polute .gitignore with unnecessary values. Only include values are are specifically required for this project.


### PR DESCRIPTION
## Summary

Adds a new `/pr` cursor command that provides a guided workflow for creating pull requests.

The command walks through:
- Running unit tests via `toolbelt unit`
- Determining the base branch using `git-town branch`
- Ensuring work is on a feature branch (not `main`/`master`)
- Verifying the working tree is clean with all changes committed
- Creating the PR using `gh pr create`

## Test Plan

- [x] Verified the command file is properly formatted markdown
- [x] Tested the workflow by using this command to create this very PR